### PR TITLE
Initial yocto layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
+meta-galapagos
+==============
 
+Galapagos is a CVE analysis service provided by The Good Penguin.
+Artifacts from a Yocto build such as data from Yocto's cve-scan can be
+uploaded to the service, in return the service will analyse the data
+and email a report with recommended mitigation steps.
 
+The Kirkstone meta-galapagos layer provides a means of integrating this
+service into your Yocto build.
+
+The layer can be added as follows:
+
+    bitbake-layers add-layer meta-galapagos
+
+Please update your local.conf to include the following:
+
+    INHERIT += "cve-check"
+    INHERIT += "galapagos-cve-check"
+
+The following variables must also be included, please note that the
+values below are examples and should be changed to meet your needs.
+
+    GALAPAGOS_PRODUCT_NAME="Penguin Feeder X12"
+    GALAPAGOS_PRODUCT_KEY="Fd3cPzYEAT5JftYR"
+    GALAPAGOS_REPORT_EMAIL="amurray@thegoodpenguin.co.uk"
+    GALAPAGOS_REPORT_INTERVAL="daily"
+
+Each time you build an image with Yocto a cve-scan will be performed and
+the output uploaded to Galapagos. A report will be emailed to the address
+in GALAPAGOS_REPORT_EMAIL. The GALAPAGOS_PRODUCT_NAME variable is used to
+provide a friendly name for your product/image. The GALAPAGOS_PRODUCT_KEY
+uniquely identifies your product to the Galapagos server, if you don't
+have one you can make one up.
+
+The GALAPAGOS_REPORT_INTERVAL variable is used to describe how frequently
+the service will send report emails. The available values are:
+
+    "build"  - a report is sent for every build
+    "daily"  - a report is sent no more than once a day
+    "weekly" - a report is sent no more than once a week
+
+For the "daily" and "weekly" values, a report is still triggered on a build
+but the report is only sent if there hasn't been any reports sent in the past
+day or week. Thus the email report will always represent the most recent
+build.
+
+Please note that no specific target is needed, the report will be generated
+upon the completion of a build of any image (e.g. core-image-minimal).

--- a/classes/galapagos-cve-check.bbclass
+++ b/classes/galapagos-cve-check.bbclass
@@ -1,0 +1,40 @@
+CVE_CHECK_MANIFEST_JSON_NAME ?= "${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.json"
+CVE_CHECK_MANIFEST_JSON_PATH ?= "${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.json"
+
+python do_galapagos_upload () {
+    manifest_path = d.getVar('CVE_CHECK_MANIFEST_JSON_PATH')
+    manifest_name = d.getVar('CVE_CHECK_MANIFEST_JSON_NAME')
+    layer_dir = d.getVar('GALAPAGOS_LAYERDIR')
+
+    product_name = d.getVar('GALAPAGOS_PRODUCT_NAME')
+    product_key = d.getVar('GALAPAGOS_PRODUCT_KEY')
+    email = d.getVar('GALAPAGOS_REPORT_EMAIL')
+    interval = d.getVar('GALAPAGOS_REPORT_INTERVAL')
+
+    if product_name is None:
+        bb.error("Please set GALAPAGOS_PRODUCT_NAME in your local.conf")
+
+    if product_key is None:
+        bb.error("Please set GALAPAGOS_PRODUCT_KEY in your local.conf")
+
+    if email is None:
+        bb.error("Please set GALAPAGOS_REPORT_EMAIL in your local.conf")
+
+    if interval != "build" and interval != "daily" and interval != "weekly":
+        bb.error("Please set GALAPAGOS_REPORT_INTERVAL in your local.conf to build, daily or weekly")
+        return
+
+    if product_name is None or product_key is None or email is None or interval is None:
+        return
+
+    try:
+        bb.plain(f"Uploading {manifest_name} to Galapagos")
+        bb.process.run(f"{layer_dir}/scripts/send-galapagos-yocto-cves.py {manifest_path} \"{product_name}\" \"{product_key}\" \"{email}\" \"{interval}\"")
+    except bb.process.CmdError as exc:
+        bb.error(f"Failed to upload CVE manifest")
+        return {}
+}
+
+addtask do_galapagos_upload before do_rm_work do_build after do_image_complete
+do_galapagos_upload[network] = "1"
+do_galapagos_upload[nostamp] = "1"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,0 +1,15 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-galapagos"
+BBFILE_PATTERN_meta-galapagos = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-galapagos = "6"
+
+LAYERDEPENDS_meta-galapagos = "core"
+LAYERSERIES_COMPAT_meta-galapagos = "kirkstone"
+
+GALAPAGOS_LAYERDIR := "${LAYERDIR}"

--- a/scripts/send-galapagos-yocto-cves.py
+++ b/scripts/send-galapagos-yocto-cves.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+
+import requests
+import argparse
+
+parser = argparse.ArgumentParser(description="Utility to send CVE reports to Galapagos")
+
+parser.add_argument("cve_json", help="Yocto generated CVE .json file")
+parser.add_argument("product_name", help="Product name")
+parser.add_argument("product_key", help="Product API key")
+parser.add_argument("email", help="Email")
+parser.add_argument("interval", help="Min interval of report: build, daily or weekly")
+
+args = parser.parse_args()
+
+url = "https://galapagos.thegoodpenguin.co.uk/upload"
+
+files = {"yocto_cves": open(args.cve_json, "rb")}
+headers = {"Product-Key": args.product_key}
+data = {"email": args.email, "product": args.product_name, "interval": args.interval}
+
+r = requests.post(url, headers=headers, data=data, files=files)
+print(r.text)


### PR DESCRIPTION
This provides an initial Yocto layer that takes the output of Yocto's cve-scan and sends it to the galapagos service.

This addresses #1 