### PR TITLE
Warn instead of error on upload failure

### DIFF
--- a/classes/galapagos-cve-check.bbclass
+++ b/classes/galapagos-cve-check.bbclass
@@ -48,7 +48,7 @@ python do_galapagos_upload () {
         bb.plain(f"Uploading {manifest_name} {'' if config is None else 'and '+config } to Galapagos")
         bb.process.run(f"{layer_dir}/scripts/send-galapagos-yocto-cves.py {manifest_path} \"{product_name}\" \"{product_key}\" \"{email}\" \"{interval}\" { '' if config is None else config}")
     except bb.process.CmdError as exc:
-        bb.error(f"Failed to upload CVE manifest")
+        bb.warn(f"Failed to upload CVE manifest")
         return {}
 }
 


### PR DESCRIPTION
If there is a failure in uploading data to Galapagos we currently error, this results in the build failing. This may not be desirable, perhaps an offline build is being performed or Galapagos is unavailable. Let's instead change this to a warning. This mirrors the behaviour of cve-update-nvd2-native upon fetch failures.