### PR TITLE
Adds uploading of the yocto layers configuration

### DIFF
--- a/classes/galapagos-cve-check.bbclass
+++ b/classes/galapagos-cve-check.bbclass
@@ -58,6 +58,7 @@ python do_galapagos_upload () {
 
         return config
 
+    layerinfo_path = d.getVar('LAYER_INFO_JSON_PATH')
     manifest_path = d.getVar('CVE_CHECK_MANIFEST_JSON_PATH')
     manifest_name = d.getVar('CVE_CHECK_MANIFEST_JSON_NAME')
     layer_dir = d.getVar('GALAPAGOS_LAYERDIR')
@@ -84,12 +85,22 @@ python do_galapagos_upload () {
         return
 
     config = obtain_kernel_config()
+    config_args = None
     if config is None:
         bb.warn("Unable to find kernel config to share with Galapagos")
+    else:
+        config_args = f"--kernel_config {config} "
+
+    layer_config = None if not os.path.isfile(layerinfo_path) else layerinfo_path
+    layer_config_args = None
+    if layer_config is None:
+        bb.warn("Unable to find layers config to share with Galapagos")
+    else:
+        layer_config_args = f"--layers_config {layer_config} "
 
     try:
-        bb.plain(f"Uploading {manifest_name} {'' if config is None else 'and '+config } to Galapagos")
-        bb.process.run(f"{layer_dir}/scripts/send-galapagos-yocto-cves.py {manifest_path} \"{product_name}\" \"{product_key}\" \"{email}\" \"{interval}\" { '' if config is None else config}")
+        bb.plain(f"Uploading {manifest_name} {'' if config is None else 'and '+config } {'' if layer_config is None else 'and '+layer_config } to Galapagos")
+        bb.process.run(f"{layer_dir}/scripts/send-galapagos-yocto-cves.py {manifest_path} \"{product_name}\" \"{product_key}\" \"{email}\" \"{interval}\" { '' if config_args is None else config_args} {'' if layer_config_args is None else layer_config_args}")
     except bb.process.CmdError as exc:
         bb.warn(f"Failed to upload CVE manifest")
         return {}
@@ -102,3 +113,4 @@ do_galapagos_upload[nostamp] = "1"
 do_galapagos_upload[depends] += "python3-requests-native:do_populate_sysroot virtual/kernel:do_shared_workdir"
 do_galapagos_layer_info[nostamp] = "1"
 do_galapagos_layer_info[depends] += "python3-requests-native:do_populate_sysroot virtual/kernel:do_shared_workdir"
+

--- a/classes/galapagos-cve-check.bbclass
+++ b/classes/galapagos-cve-check.bbclass
@@ -1,5 +1,48 @@
 CVE_CHECK_MANIFEST_JSON_NAME ?= "${IMAGE_NAME}.json"
 CVE_CHECK_MANIFEST_JSON_PATH ?= "${IMGDEPLOYDIR}/${IMAGE_NAME}.json"
+LAYER_INFO_JSON_NAME ?= "${IMAGE_NAME}${IMAGE_NAME_SUFFIX}-layersinfo.json"
+LAYER_INFO_JSON_PATH ?= "${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}-layersinfo.json"
+
+python do_galapagos_layer_info () {
+    import json
+    import os
+    import sys
+
+    sys.path.append(d.getVar('GALAPAGOS_LAYERDIR')+"/lib")
+    import gal_buildcfg
+
+    layerinfo_name = d.getVar('LAYER_INFO_JSON_NAME')
+    layerinfo_path = d.getVar('LAYER_INFO_JSON_PATH')
+
+    layers_list = layers = (d.getVar("BBLAYERS") or "").split()
+    layers_names = d.getVar('BBFILE_COLLECTIONS')
+
+    layers_dict = {}
+    layers_dict['layers'] = {}
+
+    for layer in layers_list:
+        layername=os.path.basename(layer)
+        layers_dict['layers'][layername]={}
+
+        remotes=gal_buildcfg.get_metadata_remotes(layer)
+
+        branch=gal_buildcfg.get_metadata_branch(layer)
+        revision=gal_buildcfg.get_metadata_revision(layer)
+        tags=gal_buildcfg.get_metadata_describe(layer)
+
+        remote_url = []
+        for remote in remotes:
+            remote_url.append(gal_buildcfg.get_metadata_remote_url(layer, remote))
+
+        layers_dict['layers'][layername]['url']=remote_url
+        layers_dict['layers'][layername]['branch']=branch
+        layers_dict['layers'][layername]['revision']=revision
+        if tags:
+            layers_dict['layers'][layername]['tags']=tags
+
+    with open(layerinfo_path, 'w') as f:
+        json.dump(layers_dict, f, indent=4)
+}
 
 python do_galapagos_upload () {
     def obtain_kernel_config():
@@ -53,6 +96,9 @@ python do_galapagos_upload () {
 }
 
 addtask do_galapagos_upload before do_rm_work do_build after do_image_complete
+addtask do_galapagos_layer_info before do_galapagos_upload do_rm_work do_build after do_image_complete
 do_galapagos_upload[network] = "1"
 do_galapagos_upload[nostamp] = "1"
 do_galapagos_upload[depends] += "python3-requests-native:do_populate_sysroot virtual/kernel:do_shared_workdir"
+do_galapagos_layer_info[nostamp] = "1"
+do_galapagos_layer_info[depends] += "python3-requests-native:do_populate_sysroot virtual/kernel:do_shared_workdir"

--- a/lib/gal_buildcfg.py
+++ b/lib/gal_buildcfg.py
@@ -1,0 +1,19 @@
+# This is a basic wrapper for Scarthgap and later around oe.buildcfg
+
+import oe.buildcfg
+
+def get_metadata_branch(path):
+    return oe.buildcfg.get_metadata_git_branch(path)
+
+def get_metadata_revision(path):
+    return oe.buildcfg.get_metadata_git_revision(path)
+
+def get_metadata_remotes(path):
+    return oe.buildcfg.get_metadata_git_remotes(path)
+
+def get_metadata_remote_url(path, remote):
+    return oe.buildcfg.get_metadata_git_remote_url(path, remote)
+
+def get_metadata_describe(path):
+    return oe.buildcfg.get_metadata_git_describe(path)
+

--- a/scripts/send-galapagos-yocto-cves.py
+++ b/scripts/send-galapagos-yocto-cves.py
@@ -10,7 +10,8 @@ parser.add_argument("product_name", help="Product name")
 parser.add_argument("product_key", help="Product API key")
 parser.add_argument("email", help="Email")
 parser.add_argument("interval", help="Min interval of report: build, daily or weekly")
-parser.add_argument("kernel_config", nargs='?', help="Kernel .config file for KConfig filtering")
+parser.add_argument("--kernel_config", nargs='?', help="Kernel .config file for KConfig filtering")
+parser.add_argument("--layers_config", nargs='?', help="JSON file containing meta layer configuration")
 
 args = parser.parse_args()
 
@@ -22,6 +23,8 @@ data = {"email": args.email, "product": args.product_name, "interval": args.inte
 
 if (args.kernel_config):
     files["config_file"] = open(args.kernel_config)
+if (args.layers_config):
+    files["layers_config"] = open(args.layers_config, "rb")
 
 r = requests.post(url, headers=headers, data=data, files=files)
 print(r.text)


### PR DESCRIPTION
To keep the top level similar between `kirkstone` and `scarthgap` the SCM interaction is via `lib/gal_buildcfg.py`. In scarthgap this is just a simple pass thought to `oe.buildcfg` functions. Which support `git` only currently.

However it also means in future other SCM systems can be supported if needed.