### PR TITLE
Fix errors and warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,14 @@ Artifacts from a Yocto build such as data from Yocto's cve-scan can be
 uploaded to the service, in return the service will analyse the data
 and email a report with recommended mitigation steps.
 
-The Kirkstone meta-galapagos layer provides a means of integrating this
-service into your Yocto build.
+The meta-galapagos layer provides a means of integrating this service into
+your Yocto build.
+
+Galapagos supports Scarthgap, Kirkstone, and Dunfell (after commit
+dcd40cfa375c272eda1ccc3063a48c5ec0a50ab5). Use the appropriate branch
+for the yocto version you are building.
+
+Galapagos requires meta-python and meta-oe layers.
 
 The layer can be added as follows:
 
@@ -17,6 +23,9 @@ Please update your local.conf to include the following:
 
     INHERIT += "cve-check"
     INHERIT += "galapagos-cve-check"
+
+Note that galapagos is incompatible with rm_work so you must not inherit
+rm_work when doing a galapagos build.
 
 The following variables must also be included, please note that the
 values below are examples and should be changed to meet your needs.
@@ -47,3 +56,11 @@ build.
 
 Please note that no specific target is needed, the report will be generated
 upon the completion of a build of any image (e.g. core-image-minimal).
+
+Maintenance
+===========
+
+Send pull requests, patches, comments or questions to mbullock@thegoodpenguin.co.uk
+
+Maintainers: Matthew Bullock <mbullock@thegoodpenguin.co.uk>
+

--- a/classes/galapagos-cve-check.bbclass
+++ b/classes/galapagos-cve-check.bbclass
@@ -13,6 +13,9 @@ python do_galapagos_layer_info () {
     import os
     import sys
 
+    if not d.getVar('IMAGE_NAME'):
+        bb.fatal("galapagos-cve-check should only be included in image builds")
+
     sys.path.append(d.getVar('GALAPAGOS_LAYERDIR')+"/lib")
     import gal_buildcfg
 
@@ -58,7 +61,7 @@ python do_galapagos_upload () {
         if not kernel_dir:
             return None
         config = os.path.join(kernel_dir, ".config")
-        if not os.path.exists:
+        if not os.path.exists(config):
             return None
 
         return config
@@ -82,33 +85,43 @@ python do_galapagos_upload () {
     if email is None:
         bb.error("Please set GALAPAGOS_REPORT_EMAIL in your local.conf")
 
-    if interval != "build" and interval != "daily" and interval != "weekly":
+    if not interval in ("build", "daily", "weekly"):
         bb.error("Please set GALAPAGOS_REPORT_INTERVAL in your local.conf to build, daily or weekly")
         return
 
-    if product_name is None or product_key is None or email is None or interval is None:
+    if not all((product_name, product_key, email, interval)):
+        return
+
+    if not os.path.isfile(manifest_path):
+        bb.error(f"CVE manifest '{manifest_path}' not found")
         return
 
     config = obtain_kernel_config()
-    config_args = None
+    config_args = ""
+    config_desc = ""
     if config is None:
         bb.warn("Unable to find kernel config to share with Galapagos")
     else:
         config_args = f"--kernel_config {config} "
+        config_desc = f" and {config}"
 
     layer_config = None if not os.path.isfile(layerinfo_path) else layerinfo_path
-    layer_config_args = None
+    layer_config_args = ""
+    layer_config_desc = ""
     if layer_config is None:
         bb.warn("Unable to find layers config to share with Galapagos")
     else:
         layer_config_args = f"--layers_config {layer_config} "
+        layer_config_desc = f" and {layer_config}"
 
     try:
-        bb.plain(f"Uploading {manifest_name} {'' if config is None else 'and '+config } {'' if layer_config is None else 'and '+layer_config } to Galapagos")
-        bb.process.run(f"{layer_dir}/scripts/send-galapagos-yocto-cves.py {manifest_path} \"{product_name}\" \"{product_key}\" \"{email}\" \"{interval}\" { '' if config_args is None else config_args} {'' if layer_config_args is None else layer_config_args}")
+        bb.plain(f"Uploading {manifest_name}{config_desc}{layer_desc} to Galapagos")
+        bb.process.run(f"{layer_dir}/scripts/send-galapagos-yocto-cves.py {manifest_path} \
+                         \"{product_name}\" \"{product_key}\" \"{email}\" \"{interval}\" \
+                         {config_args} {layer_config_args}")
     except bb.process.CmdError as exc:
         bb.warn(f"Failed to upload CVE manifest")
-        return {}
+        return
 }
 
 addtask do_galapagos_upload before do_rm_work do_build after do_image_complete

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,14 +1,6 @@
 # We have a conf and classes directory, add to BBPATH
 BBPATH .= ":${LAYERDIR}"
 
-# We have recipes-* directories, add to BBFILES
-BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
-            ${LAYERDIR}/recipes-*/*/*.bbappend"
-
-BBFILE_COLLECTIONS += "meta-galapagos"
-BBFILE_PATTERN_meta-galapagos = "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-galapagos = "6"
-
 LAYERDEPENDS_meta-galapagos = "core"
 LAYERSERIES_COMPAT_meta-galapagos = "scarthgap"
 

--- a/scripts/send-galapagos-yocto-cves.py
+++ b/scripts/send-galapagos-yocto-cves.py
@@ -26,7 +26,7 @@ headers = {"Product-Key": args.product_key}
 data = {"email": args.email, "product": args.product_name, "interval": args.interval}
 
 if (args.kernel_config):
-    files["config_file"] = open(args.kernel_config)
+    files["config_file"] = open(args.kernel_config, "rb")
 if (args.layers_config):
     files["layers_config"] = open(args.layers_config, "rb")
 


### PR DESCRIPTION
Fix all errors and warnings from yocto-check-layer. Fix build warning caused by no recipies in the layer. Add check for building a non-image recipe and fail with a meaningful error.
Tidy up error handling.
Update documentation to use explain that galapagos is incompatible with rm_work.