### PR TITLE
Fix running galapagos with rm_work enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Please update your local.conf to include the following:
     INHERIT += "cve-check"
     INHERIT += "galapagos-cve-check"
 
-Note that galapagos is incompatible with rm_work so you must not inherit
-rm_work when doing a galapagos build.
+Set GALAPAGOS_RECIPE_NAME to the name of the your main image recipe, eg:
+
+    GALAPAGOS_RECIPE_NAME = "core-image-sato"
 
 The following variables must also be included, please note that the
 values below are examples and should be changed to meet your needs.
@@ -61,6 +62,7 @@ Maintenance
 ===========
 
 Send pull requests, patches, comments or questions to mbullock@thegoodpenguin.co.uk
+GitHub pull requests are also welcome.
 
 Maintainers: Matthew Bullock <mbullock@thegoodpenguin.co.uk>
 

--- a/classes/galapagos-cve-check.bbclass
+++ b/classes/galapagos-cve-check.bbclass
@@ -8,10 +8,23 @@ CVE_CHECK_MANIFEST_JSON_PATH ?= "${IMGDEPLOYDIR}/${IMAGE_NAME}.json"
 LAYER_INFO_JSON_NAME ?= "${IMAGE_NAME}${IMAGE_NAME_SUFFIX}-layersinfo.json"
 LAYER_INFO_JSON_PATH ?= "${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}-layersinfo.json"
 
+def check_galapagos_recipe(d):
+    recipe_name = d.getVar("GALAPAGOS_RECIPE_NAME");
+    if not recipe_name:
+        # No recipe name specified so fall back to backwards compatible
+        # option of running on every recipe with a do_build
+        return True;
+
+    pn = d.getVar("PN");
+    return pn == recipe_name
+
 python do_galapagos_layer_info () {
     import json
     import os
     import sys
+
+    if not check_galapagos_recipe(d):
+        return;
 
     if not d.getVar('IMAGE_NAME'):
         bb.fatal("galapagos-cve-check should only be included in image builds")
@@ -66,6 +79,9 @@ python do_galapagos_upload () {
 
         return config
 
+    if not check_galapagos_recipe(d):
+        return;
+
     layerinfo_path = d.getVar('LAYER_INFO_JSON_PATH')
     manifest_path = d.getVar('CVE_CHECK_MANIFEST_JSON_PATH')
     manifest_name = d.getVar('CVE_CHECK_MANIFEST_JSON_NAME')
@@ -115,7 +131,7 @@ python do_galapagos_upload () {
         layer_config_desc = f" and {layer_config}"
 
     try:
-        bb.plain(f"Uploading {manifest_name}{config_desc}{layer_desc} to Galapagos")
+        bb.plain(f"Uploading {manifest_name}{config_desc}{layer_config_desc} to Galapagos")
         bb.process.run(f"{layer_dir}/scripts/send-galapagos-yocto-cves.py {manifest_path} \
                          \"{product_name}\" \"{product_key}\" \"{email}\" \"{interval}\" \
                          {config_args} {layer_config_args}")


### PR DESCRIPTION
Add a new variable "GALAPAGOS_RECIPE_NAME" and only run galapagos when processing that recipe.

Fixes #35 