### PR TITLE
Support all versions of Yocto after dunfell

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ and email a report with recommended mitigation steps.
 The meta-galapagos layer provides a means of integrating this service into
 your Yocto build.
 
-Galapagos supports Scarthgap, Kirkstone, and Dunfell (after commit
-dcd40cfa375c272eda1ccc3063a48c5ec0a50ab5). Use the appropriate branch
-for the yocto version you are building.
+Galapagos supports all versions of Yocto after Dunfell commit
+dcd40cfa375c272eda1ccc3063a48c5ec0a50ab5.
 
 Galapagos requires meta-python and meta-oe layers.
 

--- a/classes/galapagos-cve-check.bbclass
+++ b/classes/galapagos-cve-check.bbclass
@@ -3,10 +3,11 @@
 #
 # SPDX-License-Identifier: MIT
 #
-CVE_CHECK_MANIFEST_JSON_NAME ?= "${IMAGE_NAME}.json"
-CVE_CHECK_MANIFEST_JSON_PATH ?= "${IMGDEPLOYDIR}/${IMAGE_NAME}.json"
 LAYER_INFO_JSON_NAME ?= "${IMAGE_NAME}${IMAGE_NAME_SUFFIX}-layersinfo.json"
 LAYER_INFO_JSON_PATH ?= "${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}-layersinfo.json"
+
+# force cve json format on as it defaults off on really old versions
+CVE_CHECK_FORMAT_JSON = "1"
 
 def check_galapagos_recipe(d):
     recipe_name = d.getVar("GALAPAGOS_RECIPE_NAME");
@@ -83,8 +84,8 @@ python do_galapagos_upload () {
         return;
 
     layerinfo_path = d.getVar('LAYER_INFO_JSON_PATH')
-    manifest_path = d.getVar('CVE_CHECK_MANIFEST_JSON_PATH')
-    manifest_name = d.getVar('CVE_CHECK_MANIFEST_JSON_NAME')
+    manifest_path = d.getVar('CVE_CHECK_MANIFEST_JSON')
+    manifest_name = os.path.basename(manifest_path)
     layer_dir = d.getVar('GALAPAGOS_LAYERDIR')
 
     product_name = d.getVar('GALAPAGOS_PRODUCT_NAME')

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -2,6 +2,6 @@
 BBPATH .= ":${LAYERDIR}"
 
 LAYERDEPENDS_meta-galapagos = "core"
-LAYERSERIES_COMPAT_meta-galapagos = "scarthgap"
+LAYERSERIES_COMPAT_meta-galapagos = "dunfell kirkstone scarthgap"
 
 GALAPAGOS_LAYERDIR := "${LAYERDIR}"

--- a/lib/gal_buildcfg.py
+++ b/lib/gal_buildcfg.py
@@ -5,20 +5,60 @@
 #
 # This is a basic wrapper for Scarthgap and later around oe.buildcfg
 
-import oe.buildcfg
+buildcfg_available = True
+try:
+    import oe.buildcfg
+except ModuleNotFoundError:
+    buildcfg_available = False
 
 def get_metadata_branch(path):
-    return oe.buildcfg.get_metadata_git_branch(path)
+    if buildcfg_available:
+        return oe.buildcfg.get_metadata_git_branch(path)
+    else:
+        try:
+            rev, _ = bb.process.run('git rev-parse --abbrev-ref HEAD', cwd=path)
+        except bb.process.ExecutionError:
+            rev = '<unknown>'
+        return rev.strip()
 
 def get_metadata_revision(path):
-    return oe.buildcfg.get_metadata_git_revision(path)
+    if buildcfg_available:
+        return oe.buildcfg.get_metadata_git_revision(path)
+    else:
+        try:
+            rev, _ = bb.process.run('git rev-parse HEAD', cwd=path)
+        except bb.process.ExecutionError:
+            rev = '<unknown>'
+        return rev.strip()
 
 def get_metadata_remotes(path):
-    return oe.buildcfg.get_metadata_git_remotes(path)
+    if buildcfg_available:
+        return oe.buildcfg.get_metadata_git_remotes(path)
+    else:
+        try:
+            remotes_list, _ = bb.process.run('git remote', cwd=path)
+            remotes = remotes_list.split()
+        except bb.process.ExecutionError:
+            remotes = []
+        return remotes
 
 def get_metadata_remote_url(path, remote):
-    return oe.buildcfg.get_metadata_git_remote_url(path, remote)
+    if buildcfg_available:
+        return oe.buildcfg.get_metadata_git_remote_url(path, remote)
+    else:
+        try:
+            uri, _ = bb.process.run('git remote get-url {remote}'.format(remote=remote), cwd=path)
+        except bb.process.ExecutionError:
+            return ""
+        return uri.strip()
 
 def get_metadata_describe(path):
-    return oe.buildcfg.get_metadata_git_describe(path)
+    if buildcfg_available:
+        return oe.buildcfg.get_metadata_git_describe(path)
+    else:
+        try:
+            describe, _ = bb.process.run('git describe --tags', cwd=path)
+        except bb.process.ExecutionError:
+            return ""
+        return describe.strip()
 


### PR DESCRIPTION
Make the use of oe.buildcfg conditional on the its presence. Use CVE_CHECK_MANIFEST_JSON directly rather than our own copy of it to determine where the cve json file is.

Fixes #37 