### PR TITLE
Add support for cve_serverity_threshold and ignored_attack_vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ values below are examples and should be changed to meet your needs.
     GALAPAGOS_PRODUCT_KEY="Fd3cPzYEAT5JftYR"
     GALAPAGOS_REPORT_EMAIL="amurray@thegoodpenguin.co.uk,additional@emails.co.uk"
     GALAPAGOS_REPORT_INTERVAL="daily"
+    GALAPAGOS_CVE_SEVERITY_THRESHOLD="3.0" # Optional
+    GALAPAGOS_IGNORED_ATTACK_VECTORS="LOCAL,PHYSICAL" # Optional
 
 Each time you build an image with Yocto a cve-scan will be performed and
 the output uploaded to Galapagos. A report will be emailed to the address
@@ -53,6 +55,14 @@ For the "daily" and "weekly" values, a report is still triggered on a build
 but the report is only sent if there hasn't been any reports sent in the past
 day or week. Thus the email report will always represent the most recent
 build.
+
+The `GALAPAGOS_CVE_SEVERITY_THRESHOLD` is an optional parameter, which allows you to ignore 
+CVEs that are below a set severity threshold. Valid values are `0.0` to `10.0`
+
+The `GALAPAGOS_IGNORED_ATTACK_VECTORS` is an optional parameter. This allows you to ignore
+CVEs where their attack vector matches one provided. Multiple attack vectors can be used
+by deliminating them with a comma (,). Valid options are `PHYSICAL`, `LOCAL`, 
+`ADJACENT_NETWORK` and `NETWORK`.
 
 Please note that no specific target is needed, the report will be generated
 upon the completion of a build of any image (e.g. core-image-minimal).

--- a/classes/galapagos-cve-check.bbclass
+++ b/classes/galapagos-cve-check.bbclass
@@ -92,6 +92,8 @@ python do_galapagos_upload () {
     product_key = d.getVar('GALAPAGOS_PRODUCT_KEY')
     email = d.getVar('GALAPAGOS_REPORT_EMAIL')
     interval = d.getVar('GALAPAGOS_REPORT_INTERVAL')
+    cve_severity_threshold = d.getVar('GALAPAGOS_CVE_SEVERITY_THRESHOLD')
+    ignored_attack_vectors = d.getVar('GALAPAGOS_IGNORED_ATTACK_VECTORS')
 
     if product_name is None:
         bb.error("Please set GALAPAGOS_PRODUCT_NAME in your local.conf")
@@ -131,11 +133,21 @@ python do_galapagos_upload () {
         layer_config_args = f"--layers_config {layer_config} "
         layer_config_desc = f" and {layer_config}"
 
+    cve_severity_threshold_args = ""
+    if cve_severity_threshold is not None:
+        cve_severity_threshold_args = f"--cve_severity_threshold {cve_severity_threshold}"
+    
+    ignored_attack_vectors_args = ""
+    if ignored_attack_vectors is not None:
+        ignored_attack_vectors_args = f"--ignored_attack_vectors \"{ignored_attack_vectors}\""
+
+
     try:
         bb.plain(f"Uploading {manifest_name}{config_desc}{layer_config_desc} to Galapagos")
         bb.process.run(f"{layer_dir}/scripts/send-galapagos-yocto-cves.py {manifest_path} \
                          \"{product_name}\" \"{product_key}\" \"{email}\" \"{interval}\" \
-                         {config_args} {layer_config_args}")
+                         {config_args} {layer_config_args} \
+                         {ignored_attack_vectors_args} {cve_severity_threshold_args}")
     except bb.process.CmdError as exc:
         bb.warn(f"Failed to upload CVE manifest")
         return

--- a/scripts/send-galapagos-yocto-cves.py
+++ b/scripts/send-galapagos-yocto-cves.py
@@ -16,6 +16,8 @@ parser.add_argument("email", help="Email")
 parser.add_argument("interval", help="Min interval of report: build, daily or weekly")
 parser.add_argument("--kernel_config", nargs='?', help="Kernel .config file for KConfig filtering")
 parser.add_argument("--layers_config", nargs='?', help="JSON file containing meta layer configuration")
+parser.add_argument("--cve_severity_threshold", help="CVEs below this severity score will be ignored")
+parser.add_argument("--ignored_attack_vectors", help="Comma-seperated list of CVE attack vectors to ignore")
 
 args = parser.parse_args()
 
@@ -24,6 +26,11 @@ url = "https://galapagos.thegoodpenguin.co.uk/upload"
 files = {"yocto_cves": open(args.cve_json, "rb")}
 headers = {"Product-Key": args.product_key}
 data = {"email": args.email, "product": args.product_name, "interval": args.interval}
+
+if (args.cve_severity_threshold):
+    data["cve_severity_threshold"] = args.cve_severity_threshold
+if (args.ignored_attack_vectors):
+    data["ignored_attack_vectors"] = args.ignored_attack_vectors
 
 if (args.kernel_config):
     files["config_file"] = open(args.kernel_config, "rb")


### PR DESCRIPTION
In this PR:

- Adds support for specifying a CVE severity threshold (by using GALAPAGOS_CVE_SEVERITY_THRESHOLD)
- Adds support for ignoring CVEs that match a list of provided attack vectors (by using GALAPAGOS_IGNORED_ATTACK_VECTORS)


closes #39 