### PR TITLE
Add GALAPAGOS_EXTRA_PACKAGES

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Set GALAPAGOS_RECIPE_NAME to the name of the your main image recipe, eg:
 
     GALAPAGOS_RECIPE_NAME = "core-image-sato"
 
+If you have additional packages that are not included in the image you
+are building, for example a kernel or bootloader installed elsewhere,
+you can add them to the GALAPAGOS_EXTRA_PACKAGES variable:
+
+    GALAPAGOS_EXTRA_PACKAGES = "linux-yocto u-boot"
+
 The following variables must also be included, please note that the
 values below are examples and should be changed to meet your needs.
 

--- a/classes/galapagos-cve-check.bbclass
+++ b/classes/galapagos-cve-check.bbclass
@@ -9,6 +9,8 @@ LAYER_INFO_JSON_PATH ?= "${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}-layer
 # force cve json format on as it defaults off on really old versions
 CVE_CHECK_FORMAT_JSON = "1"
 
+GALAPAGOS_EXTRA_PACKAGES ?= ""
+
 def check_galapagos_recipe(d):
     recipe_name = d.getVar("GALAPAGOS_RECIPE_NAME");
     if not recipe_name:
@@ -67,6 +69,9 @@ python do_galapagos_layer_info () {
 }
 
 python do_galapagos_upload () {
+    import json
+    from oe.cve_check import cve_check_merge_jsons
+
     def obtain_kernel_config():
         kernel_pkg = d.getVar('PREFERRED_PROVIDER_virtual/kernel')
         if not kernel_pkg:
@@ -85,7 +90,6 @@ python do_galapagos_upload () {
 
     layerinfo_path = d.getVar('LAYER_INFO_JSON_PATH')
     manifest_path = d.getVar('CVE_CHECK_MANIFEST_JSON')
-    manifest_name = os.path.basename(manifest_path)
     layer_dir = d.getVar('GALAPAGOS_LAYERDIR')
 
     product_name = d.getVar('GALAPAGOS_PRODUCT_NAME')
@@ -114,6 +118,27 @@ python do_galapagos_upload () {
     if not os.path.isfile(manifest_path):
         bb.error(f"CVE manifest '{manifest_path}' not found")
         return
+
+    with open(manifest_path, "r") as j:
+        json_data = json.load(j)
+
+    save_pn = d.getVar("PN")
+    for pkg in d.getVar("GALAPAGOS_EXTRA_PACKAGES").split():
+        # To be able to use the CVE_CHECK_RECIPE_FILE variable we have to evaluate
+        # it with the different PN names set each time.
+        d.setVar("PN", pkg)
+        pkgfilepath = d.getVar("CVE_CHECK_RECIPE_FILE_JSON")
+        if os.path.exists(pkgfilepath):
+            with open(pkgfilepath) as j:
+                data = json.load(j)
+                cve_check_merge_jsons(json_data, data)
+
+    d.setVar("PN", save_pn)
+    manifest_path = manifest_path.rsplit(".",1)[0] + "-galapagos.json"
+    with open(manifest_path, "w") as f:
+        json.dump(json_data, f, indent=2)
+
+    manifest_name = os.path.basename(manifest_path)
 
     config = obtain_kernel_config()
     config_args = ""


### PR DESCRIPTION
Allow users to specify additional packages in the
GALAPAGOS_EXTRA_PACKAGES variable. Before uploading the CVE json file, merge the CVE jsons from those packages into it.

This allows for situations such as the kernel or boot loader being stored somewhere outside of the root filesystem.